### PR TITLE
chore(deps): enable Renovate indirect Go module updates [INFR-3403]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "postUpdateOptions": ["gomodTidy"],
+  "packageRules": [
+    {
+      "description": "Enable indirect (transitive) Go module updates, off by default in Renovate",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "minimumReleaseAge": "7 days",
+      "enabled": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Turns on Renovate's indirect (transitive) Go module updates, which are disabled by default, and adds `postUpdateOptions: ["gomodTidy"]` so `go.mod` and `go.sum` stay consistent after a bump.

## Why

The transitive CVE fixes across these providers (go-git, go-billy, otel) were all hand-authored, because neither bot proposes that class of update today:

- Dependabot cannot. Per [GitHub's docs](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates), for non-npm ecosystems it "is unable to update an indirect or transitive dependency if it would also require an update to the parent dependency". No config closes that gap.
- Renovate can, but only when told. Its [gomod manager](https://docs.renovatebot.com/modules/manager/gomod/) leaves `indirect` deps disabled unless a package rule enables them.

This mirrors the pilot in [incident-notebook#142](https://github.com/persona-id/incident-notebook/pull/142), which started opening transitive-module PRs the same day it merged.

## Risk profile

Indirect updates carry a 7 day `minimumReleaseAge` and no `automerge` label, so every transitive bump still needs a human review and the repo's test workflow to pass. Expect one initial burst of PRs as the existing transitive backlog surfaces, then a normal trickle.

Dependabot is left in place and unchanged by this PR.

Worst Case Incident: SEV(4)

🤖 Generated with Claude Code
