### PR TITLE
fix(renovate): stop proposing major bumps of indirect Go modules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":enableVulnerabilityAlerts"
   ],
   "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
@@ -11,6 +12,13 @@
       "matchDepTypes": ["indirect"],
       "minimumReleaseAge": "7 days",
       "enabled": true
+    },
+    {
+      "description": "Never propose major bumps of indirect Go modules: a Go major is a distinct module path, so the bump rewrites a require line the module graph still needs and go mod tidy reverts it. Must stay after the enable rule above; later matching rules win. Do not fold this into that rule as matchUpdateTypes, which disables indirect updates entirely because the enable decision runs before updateType is known.",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     },
     {
       "description": "Low-risk: Go module minor and patch",


### PR DESCRIPTION
Renovate has been opening major-version PRs for indirect Go modules that cannot merge. Five are open here and failing Build and Generate: #146, #148, #149, #150, #151.

In Go a major version is a distinct module path, so v15 to v17 is not an upgrade of a module, it is a swap to a different module the graph still requires. `go mod tidy` reverts each of these PRs exactly. [terraform-provider-appendonly#56](https://github.com/persona-id/terraform-provider-appendonly/pull/56) is the same change, already merged; Renovate autoclosed its five broken PRs four minutes later.

## What changed

A packageRule disabling major updates for indirect gomod deps, placed after the existing enable rule so it wins.

`:enableVulnerabilityAlerts` added to extends. Renovate appends vulnerability packageRules carrying `force`, but only clears a skipReason when `force.enabled` is truthy, and the default `vulnerabilityAlerts` object has no `enabled` key. Without this, a CVE whose only fix is an indirect major would be silently blocked. Security updates on indirect deps currently pass only as a side effect of the blanket enable.

## Verification

Renovate 44.29.4 dry-run, this branch against main: 17 updates before, 11 after. The six dropped are exactly the majors, `go-textseg` (once for go.mod, once for tools/go.mod), `posener/complete`, `goldmark-meta`, `appengine`, `yaml.v2`. Every indirect minor, patch and digest update survives, including `golang.org/x/exp`. Nothing is added. `renovate-config-validator` passes.

Folding the restriction into the enable rule as `matchUpdateTypes` instead yields 0 updates, because the enable decision runs before updateType is known. Hence the separate rule, and the note in its description.

The five open PRs need no action. `pruneStaleBranches` defaults true, so Renovate autocloses them on its next run. Closing them by hand would suppress recreation keyed on branch name plus title and only mute that one version.

Identical change to the one in gkegateway and stablepairer.

[INFR-3902](https://withpersona.atlassian.net/browse/INFR-3902)

🤖 Generated with Claude Code


[INFR-3902]: https://withpersona.atlassian.net/browse/INFR-3902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ